### PR TITLE
Fix for specifying a dependency version

### DIFF
--- a/installer.js
+++ b/installer.js
@@ -38,7 +38,7 @@ exports.install = function(opts) {
     cmdline = commandTemplate({
       opts: opts,
       target: target.name,
-      version: opts.versions[target] || 'latest'
+      version: opts.versions[target.name] || 'latest'
     });
 
     // create the npm process


### PR DESCRIPTION
By default, squirrel tries to install `package-name@latest` regardless of what the `versions` options are set to.
This fix allows `pluginDependencies` in package.json specifying exact versions to work, as well as providing `{ versions: { 'package-name': '0.1.2' } }` as an options argument in squirrel.
